### PR TITLE
Fix fragment crash and add notification log store

### DIFF
--- a/app/src/main/java/com/bhavya/smsrelay/HistoryFragment.kt
+++ b/app/src/main/java/com/bhavya/smsrelay/HistoryFragment.kt
@@ -15,22 +15,30 @@ class HistoryFragment : Fragment() {
 
     // Initialize when view is created
     private lateinit var adapter: LogsAdapter
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        _binding = FragmentHistoryBinding.inflate(inflater, container, false)
+        return binding.root
+    }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         adapter = LogsAdapter()
-        binding.recyclerView.adapter = adapter
+        binding.rvLogs.layoutManager = LinearLayoutManager(requireContext())
+        binding.rvLogs.adapter = adapter
 
-        val logs: List<LogItem> = loadLogsFromDbOrPrefs() // your source
-        adapter.submitList(logs)
+        adapter.submitList(LogStore.readAll(requireContext()))
     }
 
     override fun onResume() {
         super.onResume()
         // Refresh data when returning to this screen
         val items = LogStore.readAll(requireContext())
-        adapter.submitList(items) // or adapter.submit(items) if that's your API
+        adapter.submitList(items)
     }
 
     override fun onDestroyView() {

--- a/app/src/main/java/com/bhavya/smsrelay/LogStore.kt
+++ b/app/src/main/java/com/bhavya/smsrelay/LogStore.kt
@@ -1,0 +1,47 @@
+package com.bhavya.smsrelay
+
+import android.content.Context
+import org.json.JSONArray
+import org.json.JSONObject
+
+object LogStore {
+    private const val PREFS = "logs"
+    private const val KEY = "items"
+    private const val MAX_ENTRIES = 100
+
+    fun append(ctx: Context, item: LogItem) {
+        val prefs = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val arr = JSONArray(prefs.getString(KEY, "[]"))
+        val obj = JSONObject()
+            .put("ts", item.timestamp)
+            .put("sender", item.sender)
+            .put("msg", item.message)
+        arr.put(obj)
+        // Keep only the last MAX_ENTRIES entries
+        val finalArr = if (arr.length() > MAX_ENTRIES) {
+            val trimmed = JSONArray()
+            for (i in arr.length() - MAX_ENTRIES until arr.length()) {
+                trimmed.put(arr.getJSONObject(i))
+            }
+            trimmed
+        } else arr
+        prefs.edit().putString(KEY, finalArr.toString()).apply()
+    }
+
+    fun readAll(ctx: Context): List<LogItem> {
+        val prefs = ctx.getSharedPreferences(PREFS, Context.MODE_PRIVATE)
+        val arr = JSONArray(prefs.getString(KEY, "[]"))
+        val list = mutableListOf<LogItem>()
+        for (i in 0 until arr.length()) {
+            val obj = arr.getJSONObject(i)
+            list.add(
+                LogItem(
+                    obj.getLong("ts"),
+                    obj.getString("sender"),
+                    obj.getString("msg")
+                )
+            )
+        }
+        return list
+    }
+}

--- a/app/src/main/java/com/bhavya/smsrelay/SmsNotificationListener.kt
+++ b/app/src/main/java/com/bhavya/smsrelay/SmsNotificationListener.kt
@@ -11,6 +11,7 @@ import java.time.ZoneId
 import java.time.format.DateTimeFormatter
 import okhttp3.MediaType.Companion.toMediaType
 import okhttp3.RequestBody.Companion.toRequestBody
+import com.bhavya.smsrelay.LogItem
 
 class SmsNotificationListener : NotificationListenerService() {
 
@@ -76,7 +77,7 @@ class SmsNotificationListener : NotificationListenerService() {
             }
         }
 
-        LogStore.append(this, LogEntry(System.currentTimeMillis(), title, bodyText, "forwarded"))
+        LogStore.append(this, LogItem(System.currentTimeMillis(), title, bodyText))
     }
 
     private fun parseList(raw: String?): List<String> =

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,4 +6,3 @@ org.gradle.parallel=true
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-org.gradle.java.home=C:\\Program Files\\Android\\Android Studio\\jbr


### PR DESCRIPTION
## Summary
- Implement persistent LogStore and use it from notification listener
- Initialize HistoryFragment view binding and use correct RecyclerView id
- Remove invalid Windows-specific Java home from gradle.properties

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b806ab82e4833292598b0dc9e82428