### PR TITLE
Start ForwardService only when notifications allowed

### DIFF
--- a/app/src/main/java/com/bhavya/smsrelay/ForwardService.kt
+++ b/app/src/main/java/com/bhavya/smsrelay/ForwardService.kt
@@ -5,6 +5,8 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import androidx.core.app.NotificationCompat
+import android.Manifest
+import android.content.pm.PackageManager
 
 class ForwardService : Service() {
     companion object {
@@ -17,6 +19,10 @@ class ForwardService : Service() {
         }
 
         fun updateCounter(ctx: Context, count: Int) {
+            if (Build.VERSION.SDK_INT >= 33 &&
+                ctx.checkSelfPermission(Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                return
+            }
             val nm = ctx.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
             if (Build.VERSION.SDK_INT >= 26) {
                 val ch = NotificationChannel(CH_ID, "SMS Relay Service", NotificationManager.IMPORTANCE_LOW)

--- a/app/src/main/java/com/bhavya/smsrelay/MainActivity.kt
+++ b/app/src/main/java/com/bhavya/smsrelay/MainActivity.kt
@@ -39,8 +39,26 @@ class MainActivity : AppCompatActivity() {
         // Android 13+ notifications permission
         ensurePostNotificationsPermission()
 
-        // Start foreground service for status counter (safe even if access not yet enabled)
-        ForwardService.start(this)
+        // Start foreground service for status counter only if posting is allowed
+        val perm = Manifest.permission.POST_NOTIFICATIONS
+        if (android.os.Build.VERSION.SDK_INT < 33 ||
+            checkSelfPermission(perm) == PackageManager.PERMISSION_GRANTED) {
+            ForwardService.start(this)
+        }
+    }
+
+    override fun onRequestPermissionsResult(
+        requestCode: Int,
+        permissions: Array<out String>,
+        grantResults: IntArray
+    ) {
+        super.onRequestPermissionsResult(requestCode, permissions, grantResults)
+        if (requestCode == 1001 &&
+            grantResults.isNotEmpty() &&
+            grantResults[0] == PackageManager.PERMISSION_GRANTED
+        ) {
+            ForwardService.start(this)
+        }
     }
 
     override fun onResume() {


### PR DESCRIPTION
## Summary
- Guard ForwardService start in MainActivity behind POST_NOTIFICATIONS permission
- Launch service from permission callback when grant is received
- Skip posting notifications in ForwardService if POST_NOTIFICATIONS is missing

## Testing
- `./gradlew -Dorg.gradle.java.home=$JAVA_HOME test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b94306d9208332b763738b31d1f027